### PR TITLE
Fix researcher creation when user is created

### DIFF
--- a/backend/researchers/tests.py
+++ b/backend/researchers/tests.py
@@ -1,3 +1,41 @@
-from django.test import TestCase
+from django.test import TestCase, override_settings
+from rest_framework.test import APIClient
+from rest_framework import status
+from django.contrib.auth.models import User
+from researchers.models import Researcher
+from django.db.models.signals import post_save
+from researchers.signals import create_researcher, save_researcher
 
-# Create your tests here.
+
+@override_settings(DATABASES={"default": {"ENGINE": "django.db.backends.sqlite3", "NAME": ":memory:"}})
+class UserCreationTests(TestCase):
+    """Test user creation along with nested researcher data."""
+
+    def setUp(self):
+        # Disconnect signals to emulate environment where a Researcher is not auto-created
+        post_save.disconnect(create_researcher, sender=User)
+        post_save.disconnect(save_researcher, sender=User)
+        self.client = APIClient()
+
+    def tearDown(self):
+        # Reconnect signals after each test
+        post_save.connect(create_researcher, sender=User)
+        post_save.connect(save_researcher, sender=User)
+
+    def test_create_user_with_researcher(self):
+        payload = {
+            "username": "alice",
+            "password": "secret123",
+            "researcher": {
+                "expertise": "Physics",
+                "institution": "MIT",
+            },
+        }
+
+        response = self.client.post("/api/users/", payload, format="json")
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+        user = User.objects.get(username="alice")
+        researcher = Researcher.objects.get(user=user)
+        self.assertEqual(researcher.expertise, "Physics")
+        self.assertEqual(researcher.institution, "MIT")

--- a/backend/researchers/views.py
+++ b/backend/researchers/views.py
@@ -47,8 +47,13 @@ class UserViewSet(viewsets.ModelViewSet):
         if researcher_data:
             print("\n🔍 Données pour le chercheur :", researcher_data)  # Afficher les données du chercheur
 
-            # Cherche si un chercheur existe pour cet utilisateur
-            researcher, created = Researcher.objects.get_or_create(user=user)
+            # Remove potential user key to avoid conflicts
+            researcher_data = {k: v for k, v in researcher_data.items() if k != "user"}
+
+            # Cherche si un chercheur existe pour cet utilisateur ou le crée avec les données fournies
+            researcher, created = Researcher.objects.get_or_create(
+                user=user, defaults=researcher_data
+            )
 
             # Si le chercheur existe déjà, on le met à jour
             if not created:


### PR DESCRIPTION
## Summary
- ensure researcher defaults are applied when creating users
- add regression test for nested researcher creation

## Testing
- `DJANGO_SETTINGS_MODULE=backend.settings_sqlite python manage.py test backend.researchers.tests -v 2`


------
https://chatgpt.com/codex/tasks/task_e_6896296697608328a58e2f4a32c562cd